### PR TITLE
Break list of package managers into separate words

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Scope:
 
 Notes:
 
-- To keep this to one page, content is implicitly included by reference. You're smart enough to look up more detail elsewhere once you know the idea or command to Google. Use `apt-get`/`yum`/`dnf`/`pacman`/`pip`/`brew` (as appropriate) to install new programs.
+- To keep this to one page, content is implicitly included by reference. You're smart enough to look up more detail elsewhere once you know the idea or command to Google. Use `apt-get`, `yum`, `dnf`, `pacman`, `pip` or `brew` (as appropriate) to install new programs.
 - Use [Explainshell](http://explainshell.com/) to get a helpful breakdown of what commands, options, pipes etc. do.
 
 


### PR DESCRIPTION
Otherwise, they are seen by Markdown as a very long word. Indirectly, that might lead to the line break in the word "apt-get".

Resolves: #337